### PR TITLE
chore(package): update markdownlint-cli to version 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cz-conventional-changelog": "2.1.0",
     "globstar": "1.0.0",
     "husky": "0.15.0-beta.2",
-    "markdownlint-cli": "0.3.1",
+    "markdownlint-cli": "0.6.0",
     "npm-run-all": "4.1.2",
     "semantic-release": "11.0.2"
   },


### PR DESCRIPTION
Closes #16