### PR TITLE
chore(package): update markdownlint-cli to version 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cz-conventional-changelog": "2.1.0",
     "globstar": "1.0.0",
     "husky": "0.15.0-rc.3",
-    "markdownlint-cli": "0.8.1",
+    "markdownlint-cli": "0.9.0",
     "npm-run-all": "4.1.3",
     "semantic-release": "15.1.11"
   },


### PR DESCRIPTION
Closes #74